### PR TITLE
Use vscodeFormat in recipe action

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "React",
     "Typescript"
   ],
-  "version": "0.1.8",
+  "version": "0.1.9",
   "engines": {
     "vscode": "^1.57.0"
   },

--- a/src/commands/use-recipe.ts
+++ b/src/commands/use-recipe.ts
@@ -59,7 +59,7 @@ function insertSnippet(
 ) {
   const currentIdentation = getCurrentIndentation(editor, initialPosition);
   const decodedCode = adaptIndentation(
-    Buffer.from(recipe.code, "base64").toString("utf8"),
+    Buffer.from(recipe.vscodeFormat, "base64").toString("utf8"),
     currentIdentation
   );
   const snippet = new vscode.SnippetString(decodedCode);
@@ -90,7 +90,7 @@ function addRecipeToEditor(
 ) {
   const currentIdentation = getCurrentIndentation(editor, initialPosition);
 
-  const encodedCode = recipe.code;
+  const encodedCode = recipe.vscodeFormat;
   const decodedCode = adaptIndentation(
     Buffer.from(encodedCode, "base64").toString("utf8"),
     currentIdentation
@@ -98,7 +98,9 @@ function addRecipeToEditor(
   if (latestRecipe) {
     editor.edit((editBuilder) => {
       const previousRecipeDecodedCode = adaptIndentation(
-        Buffer.from(latestRecipe?.code || "", "base64").toString("utf8"),
+        Buffer.from(latestRecipe?.vscodeFormat || "", "base64").toString(
+          "utf8"
+        ),
         currentIdentation
       );
       const previousCodeAddedLines = previousRecipeDecodedCode.split("\n");


### PR DESCRIPTION
 - When using the recipe in the recipe action, ensure we use the `vscodeFormat`
 - Bump version for new release
