### PR TITLE
feat: implement url handler for authentication

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "React",
     "Typescript"
   ],
-  "version": "0.2.2",
+  "version": "0.2.3",
   "engines": {
     "vscode": "^1.57.0"
   },

--- a/src/commands/test-api.ts
+++ b/src/commands/test-api.ts
@@ -8,7 +8,6 @@ import { getUser } from "../graphql-api/user";
  */
 export async function testApi(): Promise<void> {
   const user = await getUser();
-  console.debug("test api");
   if (!user) {
     vscode.window.showInformationMessage(
       "Invalid API keys. Enter valid API keys from your Code Inspector profile"

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -167,8 +167,6 @@ export async function activate(context: vscode.ExtensionContext) {
     vscode.window.showInformationMessage(
       "Codiga API keys not set, [click here](https://app.codiga.io/account/auth/vscode) to configure your API keys."
     );
-  } else {
-    console.log("keys value");
   }
 }
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -23,6 +23,8 @@ import { useRecipe } from "./commands/use-recipe";
 import { createRecipe } from "./commands/create-recipe";
 import { providesCodeCompletion } from "./code-completion/assistant-completion";
 import { useRecipeCallback } from "./graphql-api/use-recipe";
+import { UriHandler } from "./utils/uriHandler";
+import { getUser } from "./graphql-api/user";
 
 // this method is called when your extension is activated
 // your extension is activated the very first time the command is executed
@@ -105,9 +107,12 @@ export async function activate(context: vscode.ExtensionContext) {
   /**
    * Register the command to send recipe usage information
    */
-  vscode.commands.registerCommand("codiga.registerUsage", async (id: number) => {
-    await useRecipeCallback(id);
-  });
+  vscode.commands.registerCommand(
+    "codiga.registerUsage",
+    async (id: number) => {
+      await useRecipeCallback(id);
+    }
+  );
 
   /**
    * Register the learn more command, this is a command that is pushed
@@ -133,6 +138,8 @@ export async function activate(context: vscode.ExtensionContext) {
     )
   );
 
+  vscode.window.registerUriHandler(new UriHandler());
+
   allLanguages.forEach((lang) => {
     const codeCompletionProvider =
       vscode.languages.registerCompletionItemProvider(
@@ -150,6 +157,19 @@ export async function activate(context: vscode.ExtensionContext) {
 
     context.subscriptions.push(codeCompletionProvider);
   });
+
+  /**
+   * Finally, attempt to get the current user. If the current user
+   * does not show, we propose to configure the API keys.
+   */
+  const currentUser = await getUser();
+  if (!currentUser) {
+    vscode.window.showInformationMessage(
+      "Codiga API keys not set, [click here](https://app.codiga.io/account/auth/vscode) to configure your API keys."
+    );
+  } else {
+    console.log("keys value");
+  }
 }
 
 // this method is called when your extension is deactivated

--- a/src/utils/uriHandler.ts
+++ b/src/utils/uriHandler.ts
@@ -1,0 +1,22 @@
+import * as vscode from "vscode";
+
+/**
+ * Save the token passed by the URL in the configuration.
+ *
+ * URL is in the form of vscode://codiga.vscode-plugin/auth?<api-token>
+ */
+export class UriHandler implements vscode.UriHandler {
+  handleUri(uri: vscode.Uri): vscode.ProviderResult<void> {
+    if (uri.path === "/auth" && uri.query) {
+      const config = vscode.workspace.getConfiguration(undefined);
+      config.update(
+        "codiga.api.token",
+        uri.query,
+        vscode.ConfigurationTarget.Global
+      );
+      vscode.window.showInformationMessage("Codiga: API token are registered");
+    } else {
+      vscode.window.showInformationMessage("Codiga: Invalid URI");
+    }
+  }
+}


### PR DESCRIPTION
**Problem**

We want to be able to register the API keys via URI handler

**Solution**
 - Declare a `UriHandler` that is registered to handle auth
 - Invite the user to go to `https://app.codiga.io/account/auth/vscode` if the user is not authenticated
 - URI handler is in the form `vscode://codiga.vscode-plugin/auth?<api-token>`