### PR TITLE
feat: handle case-insensitive shortcuts + starting slash

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "React",
     "Typescript"
   ],
-  "version": "0.3.4",
+  "version": "0.3.5",
   "engines": {
     "vscode": "^1.57.0"
   },

--- a/src/utils/textUtils.ts
+++ b/src/utils/textUtils.ts
@@ -15,12 +15,31 @@ export const getSearchTerm = (
   position: number
 ): string | undefined => {
   let pos = position;
+  /**
+   * Also include the '/' character as it can be used as
+   * a starting character.
+   */
   while (
     isCharacterAlphaNumeric(line.charCodeAt(pos)) ||
-    line.charAt(pos) === "."
+    line.charAt(pos) === "." ||
+    line.charAt(pos) === "/"
   ) {
     pos = pos - 1;
   }
 
   return line.slice(pos + 1, position + 1);
+};
+
+/**
+ * Remove the starting / if the term starts with a /
+ * removeStartingSlash("foo") returns "foo"
+ * removeStartingSlack("/bar") return "bar"
+ * @param term
+ * @returns
+ */
+export const removeStartingSlash = (term: string): string => {
+  if (term.length > 2 && term.startsWith("/")) {
+    return term.slice(1, term.length);
+  }
+  return term;
 };


### PR DESCRIPTION
**Problems**
- we do not handle case sensitivity when getting recipes from the cache
- some other tooling pollutes the results from recipes. Recipes can be triggered by having a starting `/`

**Solutions**
- Implement the case sensitivity when pulling from cache
- Implement recipe completion when we have a starting `/`