### PR TITLE
Version 0.3.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## [Unreleased]
 
+## [0.3.6]
+
+- Trigger all recipes by typing `.` or `/`
+- Fix bugs to stop showing welcome message if click on "Not show again"
+- Show presentable format in the suggestion box
+
 ## [0.1.2]
 
 - New API Token format

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "React",
     "Typescript"
   ],
-  "version": "0.3.5",
+  "version": "0.3.6",
   "engines": {
     "vscode": "^1.57.0"
   },
@@ -49,16 +49,16 @@
       {
         "title": "Codiga",
         "properties": {
-          "codiga.codeAnalysisEnabled": {
+          "codiga.showWelcomeMessage": {
             "type": "boolean",
             "default": true,
-            "description": "Enable Codiga Code Analysis Engine",
+            "description": "Show welcome messages and hints",
             "scope": "application"
           },
-          "codiga.codingAssistantCompletion": {
+          "codiga.codeAnalysisEnabled": {
             "type": "boolean",
-            "default": true,
-            "description": "Enable Coding Assistant when typing code",
+            "default": false,
+            "description": "Enable Codiga Code Analysis Engine",
             "scope": "application"
           },
           "codiga.associatedProject": {

--- a/src/commands/list-shortcuts.ts
+++ b/src/commands/list-shortcuts.ts
@@ -95,7 +95,6 @@ export async function listShorcuts(
   const path = doc.uri.path;
   const relativePath = vscode.workspace.asRelativePath(path);
   const language: Language = getLanguageForDocument(doc);
-  const basename: string | undefined = getBasename(relativePath);
   const dependencies: string[] = await getDependencies(doc);
   const initialPosition: vscode.Position = editor.selection.active;
 
@@ -163,7 +162,7 @@ export async function listShorcuts(
     quickPick,
     statusBar,
     undefined,
-    basename,
+    relativePath,
     language,
     dependencies
   );

--- a/src/commands/use-recipe.ts
+++ b/src/commands/use-recipe.ts
@@ -22,6 +22,21 @@ const latestRecipeHolder: LatestRecipeHolder = {
 };
 
 /**
+ * Show the list of keywords to show in the list of all recipes
+ * @param keywords
+ */
+const keywordsString = (recipe: AssistantRecipe): string => {
+  if (recipe.keywords.length > 0) {
+    return `(keywords: ${recipe.keywords.join(" ")})`;
+  }
+  if (recipe.shortcut && recipe.shortcut.length > 0) {
+    return `(shortcut: ${recipe.shortcut})`;
+  }
+
+  return "";
+};
+
+/**
  * Update the quickpick results by doing a GraphQL query and showing
  * the results.
  * @param quickPickEditor
@@ -68,7 +83,7 @@ async function updateQuickpickResults(
     return {
       label: r.name,
       alwaysShow: true,
-      description: `(keywords: ${r.keywords.join(" ")})`,
+      description: keywordsString(r),
       recipe: r,
     };
   });
@@ -97,7 +112,6 @@ export async function useRecipe(
   const path = doc.uri.path;
   const relativePath = vscode.workspace.asRelativePath(path);
   const language: Language = getLanguageForDocument(doc);
-  const basename: string | undefined = getBasename(relativePath);
   const dependencies: string[] = await getDependencies(doc);
   const initialPosition: vscode.Position = editor.selection.active;
 
@@ -146,7 +160,7 @@ export async function useRecipe(
       quickPick,
       statusBar,
       text && text.length > 0 ? text : undefined,
-      basename,
+      relativePath,
       language,
       dependencies
     );
@@ -227,7 +241,7 @@ export async function useRecipe(
     quickPick,
     statusBar,
     undefined, // no  term to start with
-    basename,
+    relativePath,
     language,
     dependencies
   );

--- a/src/commands/use-recipe.ts
+++ b/src/commands/use-recipe.ts
@@ -214,6 +214,7 @@ export async function useRecipe(
      */
     if (e.length > 0) {
       const recipe = e[0].recipe;
+
       await addRecipeToEditor(
         editor,
         initialPosition,

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -38,7 +38,7 @@ export const COMPOSER_FILE = "composer.json";
 export const REQUIREMENTS_FILE = "requirements.txt";
 export const GEMFILE_FILE = "Gemfile";
 
-export const AUTO_COMPLETION_CHARACTER_TRIGGER = ".";
+export const AUTO_COMPLETION_CHARACTER_TRIGGER = "./";
 
 // 10 seconds
 export const CODING_ASSISTANT_SHORTCUTS_POLLING_MS = 10000;
@@ -46,6 +46,6 @@ export const CODING_ASSISTANT_SHORTCUTS_POLLING_MS = 10000;
 export const CODING_ASSISTANT_MAX_TIME_IN_CACHE_MS = 600000;
 
 export const STARTUP_MESSAGE_MACOS =
-  "👋 use ⌘ + SHIFT + S for all shortcuts and ⌘ + SHIFT + C to search snippets.";
+  "👋 type / or . in your editor to look for snippets or use ⌘ + SHIFT + S for all shortcuts and ⌘ + SHIFT + C to search snippets.";
 export const STARTUP_MESSAGE_WINDOWS =
-  "👋 use CTRL + ALT + S for all shortcuts and CTRL + ALT + C to search snippets.";
+  "👋 type / or . in your editor to look for snippets or use CTRL + ALT + S for all shortcuts and CTRL + ALT + C to search snippets.";

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -188,10 +188,11 @@ export async function activate(context: vscode.ExtensionContext) {
   /**
    * Show a startup message for user to be familiar with the extension.
    */
-  const configuration = vscode.workspace.getConfiguration("launch");
+  const configuration = vscode.workspace.getConfiguration("codiga");
   const shouldNotShowStartupMessage =
-    configuration.get("codiga.showStartupMessage") !== undefined &&
-    configuration.get("codiga.showStartupMessage") === false;
+    !vscode.window.activeTextEditor ||
+    (configuration.get("showWelcomeMessage") !== undefined &&
+      configuration.get("showWelcomeMessage") === false);
 
   if (!shouldNotShowStartupMessage) {
     const startupMessage =
@@ -214,7 +215,11 @@ export async function activate(context: vscode.ExtensionContext) {
         }
         if (btn === MESSAGE_STARTUP_DO_NOT_SHOW_AGAIN) {
           console.log("update config");
-          configuration.update("codiga.showStartupMessage", false);
+          configuration.update(
+            "showWelcomeMessage",
+            false,
+            vscode.ConfigurationTarget.Global
+          );
         }
       });
   }
@@ -228,6 +233,7 @@ export async function activate(context: vscode.ExtensionContext) {
   vscode.workspace.onDidOpenTextDocument(async () => {
     try {
       await fetchShortcuts();
+      vscode.workspace;
     } catch (e) {
       console.debug("Error when trying to fetch shortcuts");
       console.debug(e);

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -232,7 +232,6 @@ export async function activate(context: vscode.ExtensionContext) {
   vscode.workspace.onDidOpenTextDocument(async () => {
     try {
       await fetchShortcuts();
-      vscode.workspace;
     } catch (e) {
       console.debug("Error when trying to fetch shortcuts");
       console.debug(e);

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -214,7 +214,6 @@ export async function activate(context: vscode.ExtensionContext) {
           vscode.commands.executeCommand("codiga.recipeUse");
         }
         if (btn === MESSAGE_STARTUP_DO_NOT_SHOW_AGAIN) {
-          console.log("update config");
           configuration.update(
             "showWelcomeMessage",
             false,

--- a/src/graphql-api/queries.ts
+++ b/src/graphql-api/queries.ts
@@ -138,6 +138,7 @@ export const GET_RECIPES_BY_SHORTCUT: string = gql`
       language
       creationTimestampMs
       vscodeFormat
+      presentableFormat
     }
   }
 `;

--- a/src/graphql-api/queries.ts
+++ b/src/graphql-api/queries.ts
@@ -76,6 +76,7 @@ export const GET_RECIPES: string = gql`
       language
       creationTimestampMs
       vscodeFormat
+      presentableFormat
     }
   }
 `;
@@ -105,6 +106,7 @@ export const GET_RECIPES_SEMANTIC: string = gql`
       language
       creationTimestampMs
       vscodeFormat
+      presentableFormat
     }
   }
 `;

--- a/src/graphql-api/types.ts
+++ b/src/graphql-api/types.ts
@@ -25,6 +25,7 @@ export interface AssistantRecipe {
   imports: string[];
   shortcut: string;
   vscodeFormat: string;
+  presentableFormat: string;
 }
 
 export interface FileAnalysis {

--- a/src/test/suite/testUtils.ts
+++ b/src/test/suite/testUtils.ts
@@ -72,6 +72,7 @@ export function mockRecipe(code: string): Promise<AssistantRecipe[]> {
           imports: ["use std::thread;"],
           shortcut: "spawn.thr",
           vscodeFormat: code,
+          presentableFormat: code,
         },
       ]);
     } else {

--- a/src/test/suite/utils/textUtils.test.ts
+++ b/src/test/suite/utils/textUtils.test.ts
@@ -1,0 +1,45 @@
+import * as assert from "assert";
+
+// You can import and use all API from the 'vscode' module
+// as well as import your extension to test it
+import * as vscode from "vscode";
+import { Language } from "../../../graphql-api/types";
+import {
+  removeStartingSlashOrDot,
+  shouldSkipSuggestions,
+} from "../../../utils/textUtils";
+
+suite("textUtils.ts test", () => {
+  vscode.window.showInformationMessage("Start fileUtils tests.");
+
+  test("correctly skip when there is more than one element", () => {
+    assert(shouldSkipSuggestions("foo bar", "bar", Language.C) === true);
+    assert(
+      shouldSkipSuggestions("baz    /foobar", "/foobar", Language.C) === true
+    );
+    assert(
+      shouldSkipSuggestions("baz    .foobar", ".foobar", Language.C) === true
+    );
+
+    assert(shouldSkipSuggestions("/foobar", "/foobar", Language.C) === false);
+    assert(
+      shouldSkipSuggestions("    /foobar", "/foobar", Language.C) === false
+    );
+    assert(shouldSkipSuggestions(".foobar", ".foobar", Language.C) === false);
+    assert(
+      shouldSkipSuggestions("    .foobar", ".foobar", Language.C) === false
+    );
+  });
+
+  test("skip if the element is a comment", () => {
+    assert(shouldSkipSuggestions("// foobar", "foobar", Language.C));
+    assert(shouldSkipSuggestions("/* foobar", "foobar", Language.C));
+  });
+
+  test("correctly remove slash or dot from term", () => {
+    assert.strictEqual(removeStartingSlashOrDot("/foobar"), "foobar");
+    assert.strictEqual(removeStartingSlashOrDot(".foobar"), "foobar");
+    assert.strictEqual(removeStartingSlashOrDot("foo/bar"), "foo/bar");
+    assert.strictEqual(removeStartingSlashOrDot("foo.bar"), "foo.bar");
+  });
+});

--- a/src/utils/dependencies/filter-dependencies.ts
+++ b/src/utils/dependencies/filter-dependencies.ts
@@ -1,0 +1,26 @@
+import * as vscode from "vscode";
+import { Language } from "../../graphql-api/types";
+import { filterJavascriptImports } from "./javascript";
+
+/**
+ * Filter imports for a document.
+ * @param document - the document we are inspecting.
+ * @param initialImports - list of initial imports
+ * @returns
+ */
+export function filterImports(
+  initialImports: string[],
+  language: Language,
+  document: vscode.TextDocument
+): string[] {
+  return initialImports;
+  // const documentText = document.getText();
+  // switch (language) {
+  //   case Language.Javascript: {
+  //     filterJavascriptImports(initialImports, documentText);
+  //   }
+  //   default: {
+  //     return initialImports;
+  //   }
+  // }
+}

--- a/src/utils/dependencies/javascript.ts
+++ b/src/utils/dependencies/javascript.ts
@@ -37,3 +37,19 @@ export async function readPackageFile(
   }
   return result;
 }
+
+/**
+ * Filter all Javascript/Typescript imports and only returns the one that
+ * makes sense.
+ * @param initialImports
+ * @param initialCode
+ */
+export const filterJavascriptImports = (
+  initialImports: string[],
+  initialCode: string
+): string[] => {
+  const importsInitialCode = initialCode
+    .split("\n")
+    .filter((v) => v.startsWith("import"));
+  return initialImports;
+};

--- a/src/utils/snippetUtils.ts
+++ b/src/utils/snippetUtils.ts
@@ -1,6 +1,7 @@
 import * as vscode from "vscode";
 
 import { AssistantRecipe, Language } from "../graphql-api/types";
+import { filterImports } from "./dependencies/filter-dependencies";
 import { firstLineToImport, hasImport } from "./fileUtils";
 import {
   adaptIndentation,
@@ -25,7 +26,11 @@ export const insertSnippet = (
   const snippet = new vscode.SnippetString(decodedCode);
   editor.insertSnippet(snippet, initialPosition);
 
-  for (const importStatement of recipe.imports) {
+  for (const importStatement of filterImports(
+    recipe.imports,
+    language,
+    editor.document
+  )) {
     if (!hasImport(editor.document, importStatement)) {
       const snippetString = new vscode.SnippetString(importStatement + "\n");
       const line = firstLineToImport(editor.document, language);

--- a/src/utils/snippetUtils.ts
+++ b/src/utils/snippetUtils.ts
@@ -24,13 +24,20 @@ export const insertSnippet = (
   );
   const decodedCode = decodeIndent(decodeFromBase64);
   const snippet = new vscode.SnippetString(decodedCode);
-  editor.insertSnippet(snippet, initialPosition);
 
-  for (const importStatement of filterImports(
+  /**
+   * Filter imports that really need to be added.
+   */
+  const filteredImports = filterImports(
     recipe.imports,
     language,
     editor.document
-  )) {
+  );
+
+  /**
+   * Insert the imports at the top of the file.
+   */
+  for (const importStatement of filteredImports) {
     if (!hasImport(editor.document, importStatement)) {
       const snippetString = new vscode.SnippetString(importStatement + "\n");
       const line = firstLineToImport(editor.document, language);
@@ -38,6 +45,17 @@ export const insertSnippet = (
       editor.insertSnippet(snippetString, position);
     }
   }
+
+  /**
+   * For each import we have insert, we also need to add another line
+   * and compute the final position. We just offset the lines.
+   */
+  const finalPosition = new vscode.Position(
+    initialPosition.line + filterImports.length,
+    initialPosition.character
+  );
+
+  editor.insertSnippet(snippet, finalPosition);
 };
 
 /**
@@ -64,7 +82,7 @@ export const deleteInsertedCode = async (
 
   await editor.edit((editBuilder) => {
     const previousDecodeFromBase64 = Buffer.from(
-      recipe.vscodeFormat || "",
+      recipe.presentableFormat || "",
       "base64"
     ).toString("utf8");
     const previousRecipeDecodedCode = adaptIndentation(
@@ -99,17 +117,17 @@ export const addRecipeToEditor = async (
   latestRecipeHolder: LatestRecipeHolder
 ): Promise<void> => {
   const currentIdentation = getCurrentIndentation(editor, initialPosition);
-
   if (currentIdentation === undefined) {
     return;
   }
 
-  const encodedCode = recipe.vscodeFormat;
+  const encodedCode = recipe.presentableFormat;
   const decodeFromBase64 = Buffer.from(encodedCode, "base64").toString("utf8");
   const decodedCode = adaptIndentation(
     decodeIndent(decodeFromBase64),
     currentIdentation
   );
+
   const latestRecipe = latestRecipeHolder.recipe;
 
   await editor.edit((editBuilder) => {
@@ -118,22 +136,24 @@ export const addRecipeToEditor = async (
      */
     if (latestRecipe) {
       const previousDecodeFromBase64 = Buffer.from(
-        latestRecipe?.vscodeFormat || "",
+        latestRecipe?.presentableFormat || "",
         "base64"
       ).toString("utf8");
       const previousRecipeDecodedCode = adaptIndentation(
         decodeIndent(previousDecodeFromBase64),
         currentIdentation
       );
+
       const previousCodeAddedLines = previousRecipeDecodedCode.split("\n");
       const lastLineAdded = previousCodeAddedLines.pop() || "";
-
       editBuilder.delete(
         new vscode.Range(
           initialPosition,
           new vscode.Position(
             initialPosition.line + previousCodeAddedLines.length,
-            lastLineAdded.length
+            previousCodeAddedLines.length > 1
+              ? lastLineAdded.length
+              : lastLineAdded.length + currentIdentation
           )
         )
       );

--- a/src/utils/textUtils.ts
+++ b/src/utils/textUtils.ts
@@ -1,3 +1,5 @@
+import { Language } from "../graphql-api/types";
+
 const isCharacterAlphaNumeric = (characterCode: number): boolean => {
   if (
     !(characterCode > 47 && characterCode < 58) && // numeric (0-9)
@@ -37,9 +39,51 @@ export const getSearchTerm = (
  * @param term
  * @returns
  */
-export const removeStartingSlash = (term: string): string => {
+export const removeStartingSlashOrDot = (term: string): string => {
   if (term.length > 2 && term.startsWith("/")) {
     return term.slice(1, term.length);
   }
+  if (term.length > 2 && term.startsWith(".")) {
+    return term.slice(1, term.length);
+  }
   return term;
+};
+
+/**
+ * Report if we should skip suggesting any code in the suggestions.
+ * @param line - the line where we are triggering the suggestion
+ * @param element - the element that is being selected
+ * @param language - language of the file
+ * @returns
+ */
+export const shouldSkipSuggestions = (
+  line: String,
+  element: String,
+  language: Language
+): boolean => {
+  if (!line) {
+    return true;
+  }
+  if (line.split(" ").filter((r) => r.length > 0).length > 1) {
+    return true;
+  }
+
+  /**
+   * If the line starts with //, this is a comment and we skip it
+   */
+  if (line.replace(/\s*/g, "").startsWith("//")) {
+    return true;
+  }
+
+  /**
+   * If the line starts with /*, this is a comment and we skip it
+   */
+  if (line.replace(/\s*/g, "").startsWith("/*")) {
+    return true;
+  }
+
+  if (element === "//" || element === "/*") {
+    return true;
+  }
+  return false;
 };

--- a/src/utils/textUtils.ts
+++ b/src/utils/textUtils.ts
@@ -57,8 +57,8 @@ export const removeStartingSlashOrDot = (term: string): string => {
  * @returns
  */
 export const shouldSkipSuggestions = (
-  line: String,
-  element: String,
+  line: string,
+  element: string,
   language: Language
 ): boolean => {
   if (!line) {


### PR DESCRIPTION
 - Trigger all recipes by typing `.` or `/`
 - Fix bugs to stop showing welcome message if click on "Not show again"
 - Show presentable format in the suggestion box
 - Send the pathname in the project to correctly matches with `filename_patterns`