### PR TITLE
Juli1/handle monorepo

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "React",
     "Typescript"
   ],
-  "version": "0.4.0",
+  "version": "0.4.1",
   "engines": {
     "vscode": "^1.57.0"
   },

--- a/src/utils/dependencies/get-dependencies.ts
+++ b/src/utils/dependencies/get-dependencies.ts
@@ -42,7 +42,7 @@ export async function getDependenciesFromProject(
   const pathParths = documentPath.replace(workspacePath, "");
 
   // Let's have each directory for the parts.
-  let parts: string[] | undefined = pathParths.split("/");
+  const parts: string[] | undefined = pathParths.split("/");
 
   // Let's remove the filename from the parts
   parts.pop();
@@ -57,6 +57,8 @@ export async function getDependenciesFromProject(
     );
     if (fs.existsSync(potentialDependencyFile.path)) {
       return await functionToExecute(potentialDependencyFile).catch((e) => {
+        console.debug("Codiga - error when fetching dependencies");
+        console.debug(e);
         return [];
       });
     }

--- a/src/utils/dependencies/get-dependencies.ts
+++ b/src/utils/dependencies/get-dependencies.ts
@@ -56,7 +56,9 @@ export async function getDependenciesFromProject(
       filename
     );
     if (fs.existsSync(potentialDependencyFile.path)) {
-      return await functionToExecute(potentialDependencyFile);
+      return await functionToExecute(potentialDependencyFile).catch((e) => {
+        return [];
+      });
     }
     parts.pop();
   }

--- a/src/utils/dependencies/get-dependencies.ts
+++ b/src/utils/dependencies/get-dependencies.ts
@@ -74,8 +74,7 @@ export async function getDependencies(
   document: vscode.TextDocument
 ): Promise<string[]> {
   const language: Language = getLanguageForDocument(document);
-  console.log("dependencies get ");
-  console.log(language);
+
   switch (language) {
     case Language.Javascript: {
       return await getDependenciesFromProject(

--- a/src/utils/dependencies/get-dependencies.ts
+++ b/src/utils/dependencies/get-dependencies.ts
@@ -14,29 +14,53 @@ import {
 } from "../../constants";
 
 /**
- * Search for a given filename in the project, read it
- * and return all the dependencies.
+ * Search from the top of the project a dependency file and walk backwards to the
+ * root of the project. Return nothing if no dependency is found.
+ * @param document - the current document being edited.
  * @param filename - the filename to look for
  * @param functionToExecute - the function to execute.
  * @returns
  */
 export async function getDependenciesFromProject(
+  document: vscode.TextDocument,
   filename: string,
   functionToExecute: (fileUri: vscode.Uri) => Promise<string[]>
 ): Promise<string[]> {
-  let workspaceFolders: readonly vscode.WorkspaceFolder[] = [];
+  const workspaceFolders = vscode.workspace.workspaceFolders;
 
-  if (vscode.workspace.workspaceFolders) {
-    workspaceFolders = vscode.workspace.workspaceFolders;
+  if (!workspaceFolders || workspaceFolders.length < 1) {
+    return [];
   }
 
-  for (const folder of workspaceFolders) {
-    // Read package.json for nodejs dependencies
-    const dependencyFile = vscode.Uri.joinPath(folder.uri, filename);
-    if (fs.existsSync(dependencyFile.path)) {
-      return await functionToExecute(dependencyFile);
+  // Get the workspace URI and Path
+  const workspaceUri = workspaceFolders[0].uri;
+  const workspacePath = workspaceFolders[0].uri.path;
+
+  // Get the document path
+  const documentPath = document.uri.path;
+  // Find the path of the document relative to the project path
+  const pathParths = documentPath.replace(workspacePath, "");
+
+  // Let's have each directory for the parts.
+  let parts: string[] | undefined = pathParths.split("/");
+
+  // Let's remove the filename from the parts
+  parts.pop();
+
+  // Try each directory until we reach the top directory of the project.
+  while (parts && parts.length > 0) {
+    const filePath = parts.join("/");
+    const potentialDependencyFile = vscode.Uri.joinPath(
+      workspaceUri,
+      filePath,
+      filename
+    );
+    if (fs.existsSync(potentialDependencyFile.path)) {
+      return await functionToExecute(potentialDependencyFile);
     }
+    parts.pop();
   }
+
   return [];
 }
 
@@ -50,30 +74,43 @@ export async function getDependencies(
   document: vscode.TextDocument
 ): Promise<string[]> {
   const language: Language = getLanguageForDocument(document);
+  console.log("dependencies get ");
+  console.log(language);
   switch (language) {
     case Language.Javascript: {
       return await getDependenciesFromProject(
+        document,
         NODE_PACKAGE_FILE,
         readPackageFile
       );
     }
     case Language.Typescript: {
       return await getDependenciesFromProject(
+        document,
         NODE_PACKAGE_FILE,
         readPackageFile
       );
     }
     case Language.Php: {
-      return await getDependenciesFromProject(COMPOSER_FILE, readComposerFile);
+      return await getDependenciesFromProject(
+        document,
+        COMPOSER_FILE,
+        readComposerFile
+      );
     }
     case Language.Python: {
       return await getDependenciesFromProject(
+        document,
         REQUIREMENTS_FILE,
         readRequirementsFile
       );
     }
     case Language.Ruby: {
-      return await getDependenciesFromProject(GEMFILE_FILE, readGemfile);
+      return await getDependenciesFromProject(
+        document,
+        GEMFILE_FILE,
+        readGemfile
+      );
     }
   }
   return [];


### PR DESCRIPTION
**Problem**: we only look at the `package.json` and other dependencies at the root of a project

**Solution**: walk the sources folders and find the dependency file, starting by the document being edited.