### PR TITLE
fix: use preferences for opening browser after installing the plugin

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "React",
     "Typescript"
   ],
-  "version": "0.5.2",
+  "version": "0.5.3",
   "engines": {
     "vscode": "^1.57.0"
   },
@@ -50,10 +50,16 @@
             "description": "Show welcome messages and hints",
             "scope": "application"
           },
+          "codiga.openBrowserAfterInstall": {
+            "type": "boolean",
+            "default": true,
+            "description": "Open Codiga documentation (disabled after install)",
+            "scope": "application"
+          },
           "codiga.api.token": {
             "type": "string",
             "default": "<API-TOKEN>",
-            "description": "Your Codiga API Token (Preferred authentication method)",
+            "description": "Your Codiga API Token",
             "minLength": 32,
             "maxLength": 50,
             "scope": "application"

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -27,7 +27,8 @@ export const STARTUP_MESSAGE_WINDOWS =
 
 export const PREFIX_RECENTLY_ADDED_RECIPE = "recently-added-recipe";
 
-
 // VSCode documentation
-export const VSCODE_DOCUMENTATION_SHOWN_KEY = "vs-code-documentation-shown";
-export const VSCODE_DOCUMENTATION_URL = "https://doc.codiga.io/docs/coding-assistant/coding-assistant-vscode/";
+export const PREFERENCES_OPEN_BROWSER_AFTER_INSTALL =
+  "openedBrowserAfterInstall";
+export const VSCODE_DOCUMENTATION_URL =
+  "https://doc.codiga.io/docs/coding-assistant/coding-assistant-vscode/";

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -10,8 +10,8 @@ import {
   MESSAGE_STARTUP_DO_NOT_SHOW_AGAIN,
   STARTUP_MESSAGE_MACOS,
   STARTUP_MESSAGE_WINDOWS,
-  VSCODE_DOCUMENTATION_SHOWN_KEY,
   VSCODE_DOCUMENTATION_URL,
+  PREFERENCES_OPEN_BROWSER_AFTER_INSTALL,
 } from "./constants";
 import { testApi } from "./commands/test-api";
 import {
@@ -205,12 +205,18 @@ export async function activate(context: vscode.ExtensionContext) {
 
   /**
    * Open the VSCode integration documentation only once after user installs it
-   * If there is a flag in the local storage it means the user was already redirected
-   * to the VSCode documentation
+   * We store in a preference if we should open the browser.
    */
-  if (!getFromLocalStorage(VSCODE_DOCUMENTATION_SHOWN_KEY)) {
-    setToLocalStorage(VSCODE_DOCUMENTATION_SHOWN_KEY, "true");
-    vscode.env.openExternal(vscode.Uri.parse(VSCODE_DOCUMENTATION_URL));
+  const shouldOpenBrowser =
+    configuration.get(PREFERENCES_OPEN_BROWSER_AFTER_INSTALL) === undefined ||
+    configuration.get(PREFERENCES_OPEN_BROWSER_AFTER_INSTALL) === true;
+  if (shouldOpenBrowser) {
+    await configuration.update(
+      PREFERENCES_OPEN_BROWSER_AFTER_INSTALL,
+      false,
+      vscode.ConfigurationTarget.Global
+    );
+    await vscode.env.openExternal(vscode.Uri.parse(VSCODE_DOCUMENTATION_URL));
   }
 }
 

--- a/src/test/suite/code-completion/assistant-completion.test.ts
+++ b/src/test/suite/code-completion/assistant-completion.test.ts
@@ -30,7 +30,6 @@ import {
   documentJavaRecipeImportsBetweenCommentsExpected,
 } from "../testUtils";
 import * as localStorage from "../../../utils/localStorage";
-import { VSCODE_DOCUMENTATION_SHOWN_KEY } from "../../../constants";
 
 // test recipe auto complete capabilities of the plugin, we create mocks and stub
 // for recipe fetch and recipe usage endpoints
@@ -72,12 +71,6 @@ suite("assistant-completion.ts test", () => {
         []
       );
 
-  // this will prevent to redirect to the browse for documentation on plugin activation
-  const localStorageStub: () => sinon.SinonStub = () =>
-    sandbox
-      .stub(localStorage, "getFromLocalStorage")
-      .withArgs(VSCODE_DOCUMENTATION_SHOWN_KEY);
-
   let usedRecipeMock: sinon.SinonExpectation;
 
   // these are the first state values for the settings we want to change and restore
@@ -110,7 +103,6 @@ suite("assistant-completion.ts test", () => {
 
   test("test insert suggestion from completion widget works", async () => {
     getRustRecipeStub().returns(mockRecipe(recipeForUser));
-    localStorageStub().returns("true");
 
     const document = await vscode.workspace.openTextDocument(rustUri);
     const editor = await vscode.window.showTextDocument(document);
@@ -136,7 +128,6 @@ suite("assistant-completion.ts test", () => {
       [Config.detectIdentation]: false,
     });
     getRustRecipeStub().returns(mockRecipe(recipeWithIndentVariable));
-    localStorageStub().returns("true");
 
     const document = await vscode.workspace.openTextDocument(rustUri);
     const editor = await vscode.window.showTextDocument(document);
@@ -166,7 +157,6 @@ suite("assistant-completion.ts test", () => {
       [Config.detectIdentation]: false,
     });
     getRustRecipeStub().returns(mockRecipe(recipeWithIndentVariable));
-    localStorageStub().returns("true");
 
     const document = await vscode.workspace.openTextDocument(rustUri);
     const editor = await vscode.window.showTextDocument(document);
@@ -189,7 +179,6 @@ suite("assistant-completion.ts test", () => {
 
   test("test recipe indentation in recipe insertion with two indentation spaces", async () => {
     getRustRecipeStub().returns(mockRecipe(recipeWithIndentVariable));
-    localStorageStub().returns("true");
 
     const document = await vscode.workspace.openTextDocument(rustUri);
     const editor = await vscode.window.showTextDocument(document);
@@ -214,7 +203,6 @@ suite("assistant-completion.ts test", () => {
 
   test("test imports are added after first comments in Python", async () => {
     getPythonRecipeStub().returns(mockRecipePython(pythonRecipe));
-    localStorageStub().returns("true");
 
     const document = await vscode.workspace.openTextDocument(pythonUri);
     const editor = await vscode.window.showTextDocument(document);
@@ -243,7 +231,6 @@ suite("assistant-completion.ts test", () => {
 
   test("test imports are added after first comments and package in Java", async () => {
     getJavaRecipeStub().returns(mockRecipeJava(javaRecipe));
-    localStorageStub().returns("true");
 
     const document = await vscode.workspace.openTextDocument(javaUri);
     const editor = await vscode.window.showTextDocument(document);
@@ -273,7 +260,6 @@ suite("assistant-completion.ts test", () => {
 
   test("test imports are added after first comments and before next comment in Java", async () => {
     getJavaRecipeStub().returns(mockRecipeJava(javaRecipe));
-    localStorageStub().returns("true");
 
     const document = await vscode.workspace.openTextDocument(javaUri);
     const editor = await vscode.window.showTextDocument(document);

--- a/src/test/suite/variable-transformation/variable-transformation.test.ts
+++ b/src/test/suite/variable-transformation/variable-transformation.test.ts
@@ -14,7 +14,6 @@ import {
   recipeWithTransformVariables,
   testDataUri,
 } from "../testUtils";
-import { VSCODE_DOCUMENTATION_SHOWN_KEY } from "../../../constants";
 import * as localStorage from "../../../utils/localStorage";
 
 // test there's no recipe variable in the final recipe insertion, we create mocks and stub
@@ -27,11 +26,6 @@ suite("variable transformation test", () => {
   // stub and mock two api calls required for this test suite
   let getRecipeStub: sinon.SinonStub;
   let usedRecipeMock: sinon.SinonExpectation;
-
-  // this will prevent to redirect to the browse for documentation on plugin activation
-  const localStorageStub: () => sinon.SinonStub = () => sandbox
-    .stub(localStorage, "getFromLocalStorage")
-    .withArgs(VSCODE_DOCUMENTATION_SHOWN_KEY);
 
   // this is executed before each test
   setup(() => {
@@ -55,7 +49,6 @@ suite("variable transformation test", () => {
 
   test("detect transformation variables are not present", async () => {
     getRecipeStub.returns(mockRecipe(recipeWithTransformVariables));
-    localStorageStub().returns("true");
 
     const document = await vscode.workspace.openTextDocument(uri);
     const editor = await vscode.window.showTextDocument(document);


### PR DESCRIPTION
**Problem**
We use local storage to know if we should open the browser after install. This lead to bugs with the browser being opened for each project.

**Solution**
Rely on preferences and not local storage to store if we should open the browser after install.