### PR TITLE
Escape dollar sign in shortcut insertion

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "React",
     "Typescript"
   ],
-  "version": "0.6.5",
+  "version": "0.6.6",
   "engines": {
     "vscode": "^1.70.0"
   },

--- a/src/code-completion/assistant-completion.ts
+++ b/src/code-completion/assistant-completion.ts
@@ -203,7 +203,11 @@ export async function providesCodeCompletion(
       ];
     }
 
-    snippetCompletion.insertText = new vscode.SnippetString(vscodeFormatCode);
+    // When we build a SnippetString with a dollar sign, it's substituted in the text so we escape it.
+    const codeWithDollarEscaped = vscodeFormatCode.replace(/\$/g, "\\$");
+    snippetCompletion.insertText = new vscode.SnippetString(
+      codeWithDollarEscaped
+    );
 
     /* This will suggest recipes that have been used more recently first, for this we use the timestamp
      * stored in the local storage after selecting a suggested recipe and sort them.


### PR DESCRIPTION
**Problem**

On shortcut insertion, dollar signs (`$`) are being replaced by values in the code. We should instead escape them.


**Solution**

Escape dollar sign on shortcut insertion.