### PR TITLE
Update the rules cache polling from 3 to 10 seconds

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vscode-plugin",
-  "version": "0.8.15",
+  "version": "0.8.16",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "vscode-plugin",
-      "version": "0.8.15",
+      "version": "0.8.16",
       "license": "MIT",
       "dependencies": {
         "@vscode/webview-ui-toolkit": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "React",
     "Typescript"
   ],
-  "version": "0.8.15",
+  "version": "0.8.16",
   "engines": {
     "node": "^16.0.0",
     "vscode": "^1.70.0"

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -35,8 +35,8 @@ export const AUTO_COMPLETION_CHARACTER_TRIGGER = "./";
 // 10 seconds
 export const CODING_ASSISTANT_SHORTCUTS_POLLING_MS = 10000;
 
-// 3 seconds
-export const RULES_POLLING_INTERVAL_MS = 3000;
+// 10 seconds
+export const RULES_POLLING_INTERVAL_MS = 10000;
 
 // time before we wait doing a code analysis
 export const TIME_BEFORE_STARTING_ANALYSIS_MILLISECONDS = 500;


### PR DESCRIPTION
### Changes
- Updated the rules cache polling frequency to 10 seconds to match the frequency with the JetBrains and Visual Studio plugins.
- Related docs update: https://github.com/codiga/doc.codiga.io/pull/38