### PR TITLE
chore: remove 1 keyword

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,6 @@
     "Ruby",
     "Java",
     "Javascript",
-    "Scala",
     "C/C++",
     "React",
     "Typescript"


### PR DESCRIPTION
- Removed one keyword from the package because the marketplace doesn't accept more than 10 keywords
  - `ERROR  You exceeded the number of allowed tags of 10.`
  - [VS Code FAQ](https://code.visualstudio.com/api/working-with-extensions/publishing-extension#common-questions)