### PR TITLE
chore: remove another keyword

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vscode-plugin",
-  "version": "0.8.17",
+  "version": "0.9.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "vscode-plugin",
-      "version": "0.8.17",
+      "version": "0.9.0",
       "license": "MIT",
       "dependencies": {
         "@vscode/webview-ui-toolkit": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -26,11 +26,10 @@
     "Ruby",
     "Java",
     "Javascript",
-    "C/C++",
     "React",
     "Typescript"
   ],
-  "version": "0.8.17",
+  "version": "0.9.0",
   "engines": {
     "node": "^16.0.0",
     "vscode": "^1.70.0"


### PR DESCRIPTION
- Removed another keyword (#76) from the package because the marketplace doesn't accept more than 10 keywords
  - `ERROR  You exceeded the number of allowed tags of 10.`
  - [VS Code FAQ](https://code.visualstudio.com/api/working-with-extensions/publishing-extension#common-questions)