### PR TITLE
Record the last active editor when the user changes editor tabs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vscode-plugin",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "vscode-plugin",
-      "version": "0.9.0",
+      "version": "0.9.1",
       "license": "MIT",
       "dependencies": {
         "@vscode/webview-ui-toolkit": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "React",
     "Typescript"
   ],
-  "version": "0.9.0",
+  "version": "0.9.1",
   "engines": {
     "node": "^16.0.0",
     "vscode": "^1.70.0"

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -318,6 +318,16 @@ export async function activate(context: vscode.ExtensionContext) {
   vscode.workspace.onDidChangeTextDocument(() => {
     recordLastActivity();
   });
+
+
+  /**
+   * Whenever the user switches to a different tab, we record the new active text editor,
+   * so that Codiga Assistant preview/insert has a target editor to work with.
+   */
+  vscode.window.onDidChangeActiveTextEditor(editor => {
+    if (editor)
+      recordLastEditor();
+  });
 }
 
 // this method is called when your extension is deactivated


### PR DESCRIPTION
### Changes
- The last active editor is now recorded also when the users switch tabs.
- Before the last recorded editor might not have been the one actually active, but a previously used one, and it resulted in snippet preview and insertion not applied from the Codiga Assistant, and the following exception:
```
rejected promise not handled within 1 second: Error: TextEditor#edit not possible on closed editors
extensionHostProcess.js:100
stack trace: Error: TextEditor#edit not possible on closed editors
	at Object.edit (c:\Users\<username>\AppData\Local\Programs\Microsoft VS Code\resources\app\out\vs\workbench\api\node\extensionHostProcess.js:96:51373)
	at <vscode extension path>\out\utils\snippetUtils.js:98:18
	at Generator.next (<anonymous>)
	at <vscode extension path>\out\utils\snippetUtils.js:8:71
	at new Promise (<anonymous>)
	at __awaiter (<vscode extension path>\out\utils\snippetUtils.js:4:12)
	at addRecipeToEditor (<vscode extension path>\out\utils\snippetUtils.js:89:84)
	at <vscode extension path>\out\commands\webview.js:147:56
	at Generator.next (<anonymous>)
	at fulfilled (<vscode extension path>\out\commands\webview.js:5:58)
```