### PR TITLE
Server optimizations

### DIFF
--- a/server/src/diagnostics/ignore-violation.ts
+++ b/server/src/diagnostics/ignore-violation.ts
@@ -18,14 +18,15 @@ import { CodeActionParams } from 'vscode-languageserver';
 export const provideIgnoreFixCodeActions = (
   document: TextDocument,
   range: Range,
-  context: CodeActionParams
+  context: CodeActionParams,
+  shouldComputeEdit: boolean | undefined = false
 ): CodeAction[] => {
   const diagnostics = context.context.diagnostics
     .filter(diagnostic => diagnostic.source?.toLocaleString().indexOf(DIAGNOSTIC_SOURCE) != -1);
 
   const ignoreFixes: CodeAction[] = [];
   for (const diagnostic of diagnostics) {
-    ignoreFixes.push(createIgnoreFix(diagnostic, document));
+    ignoreFixes.push(createIgnoreFix(diagnostic, document, shouldComputeEdit));
   }
 
   return ignoreFixes;
@@ -39,14 +40,15 @@ export const provideIgnoreFixCodeActions = (
  */
 export const createIgnoreFix = (
   diagnostic: Diagnostic,
-  document: TextDocument
+  document: TextDocument,
+  shouldComputeEdit: boolean | undefined = false
 ): CodeAction => {
   const ruleIdentifier = diagnostic.code;
   const title = ruleIdentifier
     ? `Ignore rule ${ruleIdentifier}`
     : "Ignore rule";
 
-  return {
+  const ignoreFix: CodeAction = {
     title: title,
     kind: CodeActionKind.QuickFix,
     /**
@@ -73,6 +75,11 @@ export const createIgnoreFix = (
       documentUri: document.uri
     }
   };
+  if (shouldComputeEdit) {
+    // @ts-ignore
+    ignoreFix.edit = createIgnoreWorkspaceEdit(document, ignoreFix.diagnostics[0]?.range);
+  }
+  return ignoreFix;
 };
 
 /**

--- a/server/src/rosie/rosiefix.ts
+++ b/server/src/rosie/rosiefix.ts
@@ -121,11 +121,12 @@ const validateOffsetsAndCreateTextEdit = (
  */
 export const provideApplyFixCodeActions = (
   document: TextDocument,
-  range: Range
+  range: Range,
+  shouldComputeEdit: boolean | undefined = false
 ): CodeAction[] => {
   const fixes = getFixesForDocument(document.uri, range);
   return fixes
-    ? fixes?.map(rosieFix => createRuleFix(document, rosieFix))
+    ? fixes?.map(rosieFix => createRuleFix(document, rosieFix, shouldComputeEdit))
     : [];
 };
 
@@ -139,13 +140,14 @@ export const provideApplyFixCodeActions = (
  */
 export const createRuleFix = (
   document: TextDocument,
-  rosieFix: RosieFix
+  rosieFix: RosieFix,
+  shouldComputeEdit: boolean | undefined = false
 ): CodeAction => {
   /*
     From CodeAction's documentation:
       If a code action provides an edit and a command, first the edit is executed and then the command.
   */
-  return {
+  const ruleFix: CodeAction = {
     title: `Fix: ${rosieFix.description}`,
     kind: CodeActionKind.QuickFix,
     //Registers the 'codiga.applyFix' command for this CodeAction, so that we can execute further
@@ -165,4 +167,9 @@ export const createRuleFix = (
       rosieFixEdits: rosieFix.edits
     }
   };
+  if (shouldComputeEdit) {
+    const rosieFixEdits = ruleFix.data.rosieFixEdits as RosieFixEdit[];
+    createAndSetRuleFixCodeActionEdit(ruleFix, document, rosieFixEdits);
+  }
+  return ruleFix;
 };

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -61,7 +61,7 @@ let clientVersion: string | undefined;
  * This is set to true for clients that don't support codeAction/resolve,
  * or they support it, but they announce their support incorrectly, e.g. due to a bug.
  */
-let shouldComputeEditInCodeAction: boolean | undefined = false;
+let isShouldComputeEditInCodeAction: boolean | undefined = false;
 
 /**
  * Starts to initialize the language server.
@@ -109,7 +109,7 @@ connection.onInitialize((_params: InitializeParams) => {
   //The condition for Eclipse can be removed, when
   // https://github.com/eclipse/lsp4e/commit/2cf0a803936635a62d7fad2d05fde78bc7ce6a17 is released.
   if (clientName?.startsWith("Eclipse IDE")) {
-    shouldComputeEditInCodeAction = true;
+    isShouldComputeEditInCodeAction = true;
   }
 
   /**
@@ -138,8 +138,8 @@ connection.onInitialize((_params: InitializeParams) => {
     if (hasApplyEditCapability && hasCodeActionLiteralSupport && params.context.diagnostics.length > 0) {
       const document = documents.get(params.textDocument.uri);
       if (document) {
-        codeActions.push(...provideApplyFixCodeActions(document, params.range, shouldComputeEditInCodeAction));
-        const ignoreFixes = provideIgnoreFixCodeActions(document, params.range, params, shouldComputeEditInCodeAction);
+        codeActions.push(...provideApplyFixCodeActions(document, params.range, isShouldComputeEditInCodeAction));
+        const ignoreFixes = provideIgnoreFixCodeActions(document, params.range, params, isShouldComputeEditInCodeAction);
         codeActions.push(...ignoreFixes);
       }
     }
@@ -154,7 +154,7 @@ connection.onInitialize((_params: InitializeParams) => {
    * only when we actually need that information, kind of lazy evaluation.
    */
   connection.onCodeActionResolve(codeAction => {
-    if (!shouldComputeEditInCodeAction && codeAction.data) {
+    if (!isShouldComputeEditInCodeAction && codeAction.data) {
       if (codeAction.data.fixKind === "rosie.rule.fix") {
         const document = documents.get(codeAction.data.documentUri);
         if (document) {


### PR DESCRIPTION
### Changes
- Removed the capability check for `textDocument/publishDiagnostics` for multiple reasons
  - diagnostics is the fundamental feature of the Rosie Language Server, so integration in a client that doesn't support diagnostics wouldn't make much sense
  - Eclipse IDE sends false for the `textDocument/publishDiagnostics` capability, so we cannot rely safely on that.
- Prepared the server to be able to compute `TextEdit`s in `onCodeAction()` in case the client doesn't support `codeAction/resolve`. This is partially the case for Eclipse, that announces this capability incorrectly due to a bug on their side. The related flag can be used to handle such cases as well.
- Added support to retrieve the Codiga API Token configuration as `codigaApiToken` besides `codiga.api.token`. This is useful at least in the case of e.g Java implementations, where creating nested objects is more cumbersome than in other languages like JS.